### PR TITLE
Enable chrony to listen for ntp-service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,4 +12,8 @@ chrony_remove_ntp: True
 
 # populate chrony_allow_deny to also have chrony serve time
 chrony_allow_deny:
- - "allow 10.0.0.0/8"
+   - "allow 10.0.0.0/8"
+
+chrony_bindaddresses:
+   - "::1"
+   - "127.0.0.1"

--- a/templates/chrony.conf
+++ b/templates/chrony.conf
@@ -117,6 +117,12 @@ logchange 0.5
 # Bind addresses
 {% if chrony_bindaddresses is defined %}
 {% for address in chrony_bindaddresses -%}
+bindaddress {{ address }}
+{% endfor %}
+{% endif %}
+
+{% if chrony_bindcmdaddresses is defined %}
+{% for address in chrony_bindcmdaddresses -%}
 bindcmdaddress {{ address }}
 {% endfor %}
 {% endif %}

--- a/vars/centos.yml
+++ b/vars/centos.yml
@@ -16,10 +16,6 @@ chrony_rtc: "rtcsync"
 chrony_clientlog: "noclientlog"
 chrony_maxstep: "makestep 10 3"
 
-chrony_bindaddresses:
- - "::1"
- - "127.0.0.1"
-
 chrony_stratumweight: "stratumweight 0"
 
 chrony_server_settings: "iburst"


### PR DESCRIPTION
Just moved chrony_bindaddresses ansible variable from role variables to defaults and added suitable lines to template to allow enabling ntp-service e.g. on admin-node.